### PR TITLE
Reusable button component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
                 "react-dom": "^18.2.0",
                 "react-icons": "^4.11.0",
                 "react-router-dom": "^6.3.0",
-                "react-test-renderer": "^18.2.0"
+                "react-test-renderer": "^18.2.0",
+                "tailwind-merge": "^1.14.0"
             },
             "devDependencies": {
                 "@commitlint/cli": "^17.7.2",
@@ -14834,6 +14835,15 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
+        },
+        "node_modules/tailwind-merge": {
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.14.0.tgz",
+            "integrity": "sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/dcastil"
+            }
         },
         "node_modules/tailwindcss": {
             "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0",
         "react-router-dom": "^6.3.0",
-        "react-test-renderer": "^18.2.0"
+        "react-test-renderer": "^18.2.0",
+        "tailwind-merge": "^1.14.0"
     },
     "devDependencies": {
         "@commitlint/cli": "^17.7.2",

--- a/src/components/Buttons/Button.jsx
+++ b/src/components/Buttons/Button.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { twMerge } from "tailwind-merge";
+function Button({ children, className, onClick }) {
+    return (
+        <button
+            className={twMerge(
+                "bg-[#FF8A57] border-2 border-[#FF8A57] py-2 px-14 rounded-lg text-white shadow-sm text-md hover:bg-white hover:text-[#FF8A57] hover:border-2 hover:border-[#FF8A57] hover:duration-300 font-bold",
+                className
+            )}
+            onClick={onClick}
+        >
+            {children}
+        </button>
+    );
+}
+
+export default Button;

--- a/src/components/Buttons/Buttons.jsx
+++ b/src/components/Buttons/Buttons.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-function Buttons() {
-    return <div>Buttons</div>;
-}
-
-export default Buttons;

--- a/src/components/Buttons/__test__/Button.test.js
+++ b/src/components/Buttons/__test__/Button.test.js
@@ -1,0 +1,7 @@
+import renderer from "react-test-renderer";
+import Button from "../Button";
+
+it("renders correctly", () => {
+    const tree = renderer.create(<Button />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/src/components/Buttons/__test__/__snapshots__/Button.test.js.snap
+++ b/src/components/Buttons/__test__/__snapshots__/Button.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<button
+  className="bg-[#FF8A57] border-2 border-[#FF8A57] py-2 px-14 rounded-lg text-white shadow-sm text-md hover:bg-white hover:text-[#FF8A57] hover:border-2 hover:border-[#FF8A57] hover:duration-300 font-bold"
+/>
+`;


### PR DESCRIPTION
In this PR I did the following tasks :

- I created a reusable button component added a default styling to it using Tailwind CSS and added a tailwind merge function to override the default style when needed.

- I chose default styling for the  most used components like sign in button 
# Screenshot
![image](https://github.com/202306-NEA-DZ-FEW/StudentStore/assets/127650953/aab00988-cf42-4bda-a6c3-38b79016af33)

**How to use the button**

to use this component use the opening and closing tags add the title of the button you want to type 

![image](https://github.com/202306-NEA-DZ-FEW/StudentStore/assets/127650953/2d4cec05-95f7-4d77-a916-d7b9798beff8)



add your styling if you want to override the default styling for example:

to use the offer button in the navbar 
![image](https://github.com/202306-NEA-DZ-FEW/StudentStore/assets/127650953/0ebad5e3-9fa6-47ff-ade8-8f49d925da10)
``` js
<Button className=' bg-[#585785] border-none text-white px-6 hover:bg-[#7874F2] hover:text-white rounded-[20px]'>
                    Offer
</Button>
```







 

fix #10

# Related Issue

- Resolve #10