### PR TITLE
 Product card component

### DIFF
--- a/src/components/ProductCard/ProductCard.jsx
+++ b/src/components/ProductCard/ProductCard.jsx
@@ -1,7 +1,44 @@
+import Image from "next/image";
 import React from "react";
+import { FaShoppingCart } from "react-icons/fa";
 
 function ProductCard() {
-    return <div>ProductCard</div>;
+    return (
+        <div className='card w-[270px]  bg-white shadow-xl'>
+            <div className='relative flex justify-center items-center m-4 mb-0 rounded-lg h-[80%]  '>
+                <figure className='  rounded-lg '>
+                    <Image
+                        className='object-cover  scale-100 rounded-lg transition-transform hover:scale-105 duration-300 ease-in-out overflow-hidden'
+                        src=''
+                        width={200}
+                        height={200}
+                        alt='Picture of the product'
+                    />
+                    <div className='absolute top-0 m-2  left-0 rounded-full '>
+                        <p className='rounded-full bg-[#7874F2] p-1 text-[8px] font-bold uppercase tracking-wide text-white sm:py-1 sm:px-3'>
+                            Sale
+                        </p>
+                    </div>
+                </figure>
+            </div>
+
+            <div className='mt-1 px-5 p-4  mb-2 '>
+                <h2 className='card-title text-slate-900 text-xl max-w-lg tracking-tight font-bold text-center '>
+                    Nike Air MX Super 2500
+                </h2>
+                <div className='mt-3 mb-4 w-full  flex items-center   justify-between   text-slate-600 '>
+                    <p className=' badge badge-outline '>category</p>
+                    <p>location</p>
+                </div>
+                <div className=' flex items-center   justify-between font-semibold text-slate-900 '>
+                    <p className='text-xl '>$449</p>
+                    <button className='text-3xl text-[#FF8A57] hover:text-orange-500'>
+                        <FaShoppingCart />
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
 }
 
 export default ProductCard;

--- a/src/components/ProductCard/__test__/ProductCard.test.js
+++ b/src/components/ProductCard/__test__/ProductCard.test.js
@@ -1,0 +1,8 @@
+import renderer from "react-test-renderer";
+
+import ProductCard from "../ProductCard";
+
+it("renders correctly", () => {
+    const tree = renderer.create(<ProductCard />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/src/components/ProductCard/__test__/__snapshots__/ProductCard.test.js.snap
+++ b/src/components/ProductCard/__test__/__snapshots__/ProductCard.test.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="card w-[270px]  bg-white shadow-xl"
+>
+  <div
+    className="relative flex justify-center items-center m-4 mb-0 rounded-lg h-[80%]  "
+  >
+    <figure
+      className="  rounded-lg "
+    >
+      <img
+        alt="Picture of the product"
+        className="object-cover  scale-100 rounded-lg transition-transform hover:scale-105 duration-300 ease-in-out overflow-hidden"
+        data-nimg="1"
+        decoding="async"
+        height={200}
+        onError={[Function]}
+        onLoad={[Function]}
+        src=""
+        style={
+          Object {
+            "color": "transparent",
+          }
+        }
+        width={200}
+      />
+      <div
+        className="absolute top-0 m-2  left-0 rounded-full "
+      >
+        <p
+          className="rounded-full bg-[#7874F2] p-1 text-[8px] font-bold uppercase tracking-wide text-white sm:py-1 sm:px-3"
+        >
+          Sale
+        </p>
+      </div>
+    </figure>
+  </div>
+  <div
+    className="mt-1 px-5 p-4  mb-2 "
+  >
+    <h2
+      className="card-title text-slate-900 text-xl max-w-lg tracking-tight font-bold text-center "
+    >
+      Nike Air MX Super 2500
+    </h2>
+    <div
+      className="mt-3 mb-4 w-full  flex items-center   justify-between   text-slate-600 "
+    >
+      <p
+        className=" badge badge-outline "
+      >
+        category
+      </p>
+      <p>
+        location
+      </p>
+    </div>
+    <div
+      className=" flex items-center   justify-between font-semibold text-slate-900 "
+    >
+      <p
+        className="text-xl "
+      >
+        $449
+      </p>
+      <button
+        className="text-3xl text-[#FF8A57] hover:text-orange-500"
+      >
+        <svg
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          strokeWidth="0"
+          style={
+            Object {
+              "color": undefined,
+            }
+          }
+          viewBox="0 0 576 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M528.12 301.319l47.273-208C578.806 78.301 567.391 64 551.99 64H159.208l-9.166-44.81C147.758 8.021 137.93 0 126.529 0H24C10.745 0 0 10.745 0 24v16c0 13.255 10.745 24 24 24h69.883l70.248 343.435C147.325 417.1 136 435.222 136 456c0 30.928 25.072 56 56 56s56-25.072 56-56c0-15.674-6.447-29.835-16.824-40h209.647C430.447 426.165 424 440.326 424 456c0 30.928 25.072 56 56 56s56-25.072 56-56c0-22.172-12.888-41.332-31.579-50.405l5.517-24.276c3.413-15.018-8.002-29.319-23.403-29.319H218.117l-6.545-32h293.145c11.206 0 20.92-7.754 23.403-18.681z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,10 +1,13 @@
+import { collection, getDocs } from "firebase/firestore";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import * as React from "react";
-import { db } from "@/util/firebase";
-import { collection, getDocs } from "firebase/firestore";
+
+import ProductCard from "@/components/ProductCard/ProductCard";
+
 import Layout from "@/layout/Layout";
+import { db } from "@/util/firebase";
 
 export default function HomePage() {
     const { t } = useTranslation("common");
@@ -17,6 +20,7 @@ export default function HomePage() {
     });
     return (
         <Layout>
+            <ProductCard />
             <p>{t("test")}</p>
             <div style={{ display: "flex", flexDirection: "row", gap: "20px" }}>
                 <Link href='/' locale='en'>


### PR DESCRIPTION
In this pull request, I have added a reusable product card component that can be utilized across multiple pages. This component is designed to showcase essential product details, including the image, name, category, location, price, and an 'offer' indicator that specifies whether the product is available for sale or borrowing.
 

I integrated details into the card to evaluate its styling and responsiveness. This allowed me to test how the component behaves when using images of different resolutions and on screens of different sizes, ensuring it maintains a visually appealing and functional design.
 # Screenshot :
![image](https://github.com/202306-NEA-DZ-FEW/StudentStore/assets/122048230/c495e93c-0699-4d7c-979a-d186a0d1f4a7)


fix #11

# Related Issue

- Resolve #11